### PR TITLE
add new 'headers_to_sign' option to sign custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ to:
 
     Authorization = APIAuth-HMAC-DIGEST_NAME 'client access id':'signature'
 
+If you want to sign custom headers, you can pass them as an array of strings in the options like so:
+
+``` ruby
+    @signed_request = ApiAuth.sign!(@request, @access_id, @secret_key, headers_to_sign: %w[HTTP_HEADER_NAME])
+```
+
+With the specified headers values being at the end of the canonical string in the same order.
+
 ### ActiveResource Clients
 
 ApiAuth can transparently protect your ActiveResource communications with a

--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -105,7 +105,7 @@ module ApiAuth
     end
 
     def hmac_signature(headers, secret_key, options)
-      canonical_string = headers.canonical_string(options[:override_http_method])
+      canonical_string = headers.canonical_string(options[:override_http_method], options[:headers_to_sign])
       digest = OpenSSL::Digest.new(options[:digest])
       b64_encode(OpenSSL::HMAC.digest(digest, secret_key, canonical_string))
     end

--- a/lib/api_auth/headers.rb
+++ b/lib/api_auth/headers.rb
@@ -47,18 +47,24 @@ module ApiAuth
       @request.timestamp
     end
 
-    def canonical_string(override_method = nil)
+    def canonical_string(override_method = nil, headers_to_sign = [])
       request_method = override_method || @request.http_method
 
       if request_method.nil?
         raise ArgumentError, 'unable to determine the http method from the request, please supply an override'
       end
 
-      [request_method.upcase,
-       @request.content_type,
-       @request.content_md5,
-       parse_uri(@request.original_uri || @request.request_uri),
-       @request.timestamp].join(',')
+      headers = @request.fetch_headers
+
+      canonical_array = [request_method.upcase,
+                         @request.content_type,
+                         @request.content_md5,
+                         parse_uri(@request.original_uri || @request.request_uri),
+                         @request.timestamp]
+      
+      headers_to_sign.each { |h| canonical_array << headers[h] if headers[h].present? }
+
+      canonical_array.join(',')
     end
 
     # Returns the authorization header from the request's headers


### PR DESCRIPTION
Adds the possibility to sign custom headers via a headers_to_sign
option that will be passed as an array containing the headers names